### PR TITLE
Update to support 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
- language: scala
- scala:
-   - "2.11.8"
-   - "2.12.0"
- jdk:
-   - oraclejdk8
+import: scala/scala-dev:travis/default.yml
+
+language: scala
+
+scala:
+  - "2.11.12"
+  - "2.12.10"
+  - "2.13.1"
+
+env:
+  - ADOPTOPENJDK=8
+  - ADOPTOPENJDK=11

--- a/build.sbt
+++ b/build.sbt
@@ -6,23 +6,16 @@ description := "Scaldi - Scala Dependency Injection Library"
 homepage := Some(url("http://scaldi.org"))
 licenses := Seq("Apache License, ASL Version 2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0"))
 
-crossScalaVersions := Seq("2.11.8", "2.12.0")
-scalaVersion := "2.12.0"
+crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.1")
+scalaVersion := "2.13.1"
 
 scalacOptions ++= Seq("-deprecation", "-feature")
 
-scalacOptions ++= {
-  if (scalaVersion.value startsWith "2.12")
-    Seq.empty
-  else
-    Seq("-target:jvm-1.7")
-}
-
 libraryDependencies ++= Seq(
   "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-  "com.typesafe" % "config" % "1.3.1" % "optional",
-
-  "org.scalatest" %% "scalatest" % "3.0.0" % "test"
+  "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.3",
+  "com.typesafe" % "config" % "1.4.0" % Optional,
+  "org.scalatest" %% "scalatest" % "3.0.8" % Test
 )
 
 fork := true
@@ -41,9 +34,8 @@ publishTo := Some(
 
 // Site and docs
 
-site.settings
-site.includeScaladoc()
-ghpages.settings
+enablePlugins(SiteScaladocPlugin)
+enablePlugins(GhpagesPlugin)
 
 // nice *magenta* prompt!
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.3.7

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
-
-addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")
-addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
-addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
+addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "1.4.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.6.3")

--- a/src/main/scala-2.11/scaldi/internal/WireCrossHelper.scala
+++ b/src/main/scala-2.11/scaldi/internal/WireCrossHelper.scala
@@ -1,0 +1,9 @@
+package scaldi.internal
+
+import scala.reflect.macros.blackbox
+
+private[scaldi] object WireCrossHelper {
+  /** Helper for creating a named arg tree when cross building. */
+  def CrossNamedArg(c: blackbox.Context)(lhs: c.universe.Tree, rhs: c.universe.Tree): c.universe.TermTree =
+    c.universe.AssignOrNamedArg(lhs, rhs)
+}

--- a/src/main/scala-2.12/scaldi/internal/WireCrossHelper.scala
+++ b/src/main/scala-2.12/scaldi/internal/WireCrossHelper.scala
@@ -1,0 +1,9 @@
+package scaldi.internal
+
+import scala.reflect.macros.blackbox
+
+private[scaldi] object WireCrossHelper {
+  /** Helper for creating a named arg tree when cross building. */
+  def CrossNamedArg(c: blackbox.Context)(lhs: c.universe.Tree, rhs: c.universe.Tree): c.universe.TermTree =
+    c.universe.AssignOrNamedArg(lhs, rhs)
+}

--- a/src/main/scala-2.13/scaldi/internal/WireCrossHelper.scala
+++ b/src/main/scala-2.13/scaldi/internal/WireCrossHelper.scala
@@ -1,0 +1,9 @@
+package scaldi.internal
+
+import scala.reflect.macros.blackbox
+
+private[scaldi] object WireCrossHelper {
+  /** Helper for creating a named arg tree when cross building. */
+  def CrossNamedArg(c: blackbox.Context)(lhs: c.universe.Tree, rhs: c.universe.Tree): c.universe.TermTree =
+    c.universe.NamedArg(lhs, rhs)
+}

--- a/src/main/scala/scaldi/Binding.scala
+++ b/src/main/scala/scaldi/Binding.scala
@@ -16,7 +16,7 @@ trait Identifiable {
     */
   def condition: Option[() => Condition]
 
-  protected lazy val resolvedCondition = condition map (fn ⇒ fn())
+  protected lazy val resolvedCondition = condition map (fn => fn())
 
   def isDefinedFor(desiredIdentifiers: List[Identifier]) =
     Identifier.sameAs(identifiers, desiredIdentifiers) &&
@@ -96,11 +96,11 @@ trait BindingWithLifecycle extends Identifiable {
 
   def init(lifecycleManager: LifecycleManager): Unit = {
     resolvedCondition match {
-      case None ⇒
+      case None =>
         get(lifecycleManager)
-      case Some(c) if c.dynamic || c.satisfies(Nil) ⇒
+      case Some(c) if c.dynamic || c.satisfies(Nil) =>
         get(lifecycleManager)
-      case _ ⇒
+      case _ =>
       // do nothing because eager binding should not be initialized
     }
   }

--- a/src/main/scala/scaldi/Injector.scala
+++ b/src/main/scala/scaldi/Injector.scala
@@ -205,7 +205,7 @@ class MutableInjectorAggregation(chain: List[Injector]) extends InjectorWithLife
     * Mutates current injector replacing it with the one in the parameters
     * @param newParentInjector the replacement for current injector
     */
-  override def injector_=(newParentInjector: Injector) {
+  override def injector_=(newParentInjector: Injector): Unit = {
     super.injector_=(newParentInjector)
     initInjector(newParentInjector)
   }
@@ -228,7 +228,7 @@ class MutableInjectorAggregation(chain: List[Injector]) extends InjectorWithLife
     * passed in the parameters.
     * @param newParentInjector the injector which will be parent injector for composed injectors
     */
-  private def initInjector(newParentInjector: Injector) {
+  private def initInjector(newParentInjector: Injector): Unit = {
     chain foreach {
       case childInjector: MutableInjectorUser => childInjector.injector = newParentInjector
       case _ => // skip
@@ -263,7 +263,7 @@ trait MutableInjectorUser extends MutableInjector { self: Injector with Freezabl
     * Works only if current injector is not frozen
     * @param newParentInjector the replacement for current injector
     */
-  def injector_=(newParentInjector: Injector) {
+  def injector_=(newParentInjector: Injector): Unit = {
     if (isFrozen) throw new InjectException("Injector already frozen, so you can't mutate it anymore!")
 
     _injector = newParentInjector

--- a/src/main/scala/scaldi/Module.scala
+++ b/src/main/scala/scaldi/Module.scala
@@ -6,8 +6,8 @@ import java.util.Properties
 import com.typesafe.config._
 import scaldi.util.Util._
 
-import scala.collection.JavaConverters._
 import scala.concurrent.duration.Duration
+import scala.jdk.CollectionConverters._
 import scala.reflect.runtime.universe.{Type, typeOf}
 import scala.sys._
 import scala.util.control.NonFatal
@@ -114,7 +114,8 @@ object Args {
    * @param args array that will be binded to `'args` identifier
    * @return new `DynamicModule` with a binding defined for command line arguments
    */
-  def apply(args: Array[String]): Injector = DynamicModule(m => m.bind[Array[String]] identifiedBy 'args toNonLazy args)
+  def apply(args: Array[String]): Injector =
+    DynamicModule(m => m.bind[Array[String]] identifiedBy Symbol("args") toNonLazy args)
 }
 
 /**

--- a/src/main/scala/scaldi/Wire.scala
+++ b/src/main/scala/scaldi/Wire.scala
@@ -1,7 +1,9 @@
 package scaldi
 
+import scaldi.internal.WireCrossHelper._
+
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox.Context
+import scala.reflect.macros.blackbox
 
 trait Wire {
   def injected[T]: T = macro WireBuilder.wireNoArgImpl[T]
@@ -12,7 +14,7 @@ trait Wire {
 }
 
 class WireBuilder {
-  def build[T: c.WeakTypeTag](c: Context)(overrides: Seq[c.Tree]): c.Expr[T] = {
+  def build[T: c.WeakTypeTag](c: blackbox.Context)(overrides: Seq[c.Tree]): c.Expr[T] = {
     val validatedOverrides = overrides.map(o => extractProperty(c)(o))
 
     validatedOverrides find (_.isLeft) match {
@@ -21,7 +23,7 @@ class WireBuilder {
     }
   }
 
-  def extractPropertyName(c: Context)(tree: c.Tree) = {
+  def extractPropertyName(c: blackbox.Context)(tree: c.Tree) = {
     import c.universe._
 
     tree match {
@@ -33,7 +35,7 @@ class WireBuilder {
     }
   }
 
-  def extractProperty(c: Context)(tree: c.Tree): Either[String, (String, c.Tree)] = {
+  def extractProperty(c: blackbox.Context)(tree: c.Tree): Either[String, (String, c.Tree)] = {
     import c.universe._
 
     tree match {
@@ -50,7 +52,7 @@ class WireBuilder {
     }
   }
 
-  def wireParam(c: Context)(param: c.Symbol, wiredType: c.Type, defaultSupported: Boolean, validOverrides: Map[String, c.Tree]): Either[String, c.Tree] = {
+  def wireParam(c: blackbox.Context)(param: c.Symbol, wiredType: c.Type, defaultSupported: Boolean, validOverrides: Map[String, c.Tree]): Either[String, c.Tree] = {
     import c.universe._
 
     val name = param.name.decodedName.toString
@@ -60,19 +62,19 @@ class WireBuilder {
     if (!defaultSupported && hasDefault)
       Left(s"Argument $name has a default value, but default values are only supported for the first argument list.")
     else
-      Right(AssignOrNamedArg(
+      Right(CrossNamedArg(c)(
         Ident(TermName(name)),
-        validOverrides get name getOrElse {
+        validOverrides.getOrElse(name, {
           if (hasDefault) q"injectWithConstructorDefault[$tpe, $wiredType]($name)"
           else q"inject[$tpe]"
-        }
+        })
       ))
   }
 
-  def wireParamList(c: Context)(paramList: List[c.Symbol], wiredType: c.Type, defaultSupported: Boolean, validOverrides: Map[String, c.Tree]) =
+  def wireParamList(c: blackbox.Context)(paramList: List[c.Symbol], wiredType: c.Type, defaultSupported: Boolean, validOverrides: Map[String, c.Tree]) =
     paramList map (param => wireParam(c)(param, wiredType, defaultSupported, validOverrides))
 
-  def wireType[T: c.WeakTypeTag](c: Context)(validOverrides: Map[String, c.Tree]) = {
+  def wireType[T: c.WeakTypeTag](c: blackbox.Context)(validOverrides: Map[String, c.Tree]) = {
     import c.universe._
 
     val tpe = implicitly[c.WeakTypeTag[T]].tpe
@@ -107,7 +109,7 @@ class WireBuilder {
     }
   }
 
-  def error[T](c: Context, message: String): c.Expr[T] = {
+  def error[T](c: blackbox.Context, message: String): c.Expr[T] = {
     import c.universe._
 
     c.error(c.enclosingPosition, message)
@@ -116,9 +118,9 @@ class WireBuilder {
 }
 
 object WireBuilder {
-  def wireNoArgImpl[T: c.WeakTypeTag](c: Context): c.Expr[T] =
+  def wireNoArgImpl[T: c.WeakTypeTag](c: blackbox.Context): c.Expr[T] =
     wireImpl[T](c)()
 
-  def wireImpl[T: c.WeakTypeTag](c: Context)(overrides: c.Tree*): c.Expr[T] =
+  def wireImpl[T: c.WeakTypeTag](c: blackbox.Context)(overrides: c.Tree*): c.Expr[T] =
     new WireBuilder().build[T](c)(overrides)
 }

--- a/src/test/scala/scaldi/ConditionSpec.scala
+++ b/src/test/scala/scaldi/ConditionSpec.scala
@@ -75,7 +75,7 @@ class ConditionSpec extends WordSpec with Matchers {
       var initialized = false
 
       implicit val inj = new Module {
-        bind [String] when cond toNonLazy "foo" initWith (_ ⇒ initialized = true)
+        bind [String] when cond toNonLazy "foo" initWith (_ => initialized = true)
       }
 
       inj.initNonLazy()
@@ -88,7 +88,7 @@ class ConditionSpec extends WordSpec with Matchers {
       var initialized = false
 
       implicit val inj = new Module {
-        bind [String] when cond toNonLazy "foo" initWith (_ ⇒ initialized = true)
+        bind [String] when cond toNonLazy "foo" initWith (_ => initialized = true)
       }
 
       inj.initNonLazy()
@@ -111,7 +111,7 @@ class ConditionSpec extends WordSpec with Matchers {
       var initialized = false
 
       implicit val inj = new Module {
-        bind[String] when cond toNonLazy "foo" initWith (_ ⇒ initialized = true)
+        bind[String] when cond toNonLazy "foo" initWith (_ => initialized = true)
       }
 
       inj.initNonLazy()

--- a/src/test/scala/scaldi/IdentifierSpec.scala
+++ b/src/test/scala/scaldi/IdentifierSpec.scala
@@ -11,7 +11,7 @@ class IdentifierSpec extends WordSpec with Matchers {
       }
 
       "be converted from symbol" in {
-        getId('sym) should equal (StringIdentifier("sym"))
+        getId(Symbol("sym")) should equal (StringIdentifier("sym"))
       }
 
       "be converted from class" in {
@@ -25,8 +25,8 @@ class IdentifierSpec extends WordSpec with Matchers {
       }
 
       "should match for the same identifier types" in {
-        getId('publisher) sameAs getId("publisher") should be (true)
-        getId('user) sameAs getId("publisher") should be (false)
+        getId(Symbol("publisher")) sameAs getId("publisher") should be (true)
+        getId(Symbol("user")) sameAs getId("publisher") should be (false)
 
         getId(classOf[String]) sameAs getId(classOf[String]) should be (true)
         getId(classOf[DateFormat]) sameAs getId(classOf[String]) should be (false)

--- a/src/test/scala/scaldi/InjectableSpec.scala
+++ b/src/test/scala/scaldi/InjectableSpec.scala
@@ -9,12 +9,12 @@ class InjectableSpec extends WordSpec with Matchers {
 
     "be useable within classes that are instantiated within module and have implicit injector" in {
       val module = new TcpModule :: DynamicModule({ m =>
-        m.binding identifiedBy 'tcpHost to "test"
-        m.binding identifiedBy 'welcome to "Hello user!"
+        m.binding identifiedBy Symbol("tcpHost") to "test"
+        m.binding identifiedBy Symbol("welcome") to "Hello user!"
       })
 
-      val binding = module.getBinding(List('tcpServer))
-      binding should be ('defined)
+      val binding = module.getBinding(List(Symbol("tcpServer")))
+      binding should be (Symbol("defined"))
 
       val server = binding.get.get.get.asInstanceOf[TcpServer]
       server.port should equal (1234)
@@ -23,13 +23,13 @@ class InjectableSpec extends WordSpec with Matchers {
     }
 
     "treat binding that return None as non-defined and use default or throw an exception if no default provided" in {
-      val module = new TcpModule :: DynamicModule(_.bind [String] identifiedBy 'welcome to None) :: DynamicModule({ m =>
-        m.binding identifiedBy 'tcpHost to "test"
-        m.binding identifiedBy 'welcome to "Hello user!"
+      val module = new TcpModule :: DynamicModule(_.bind [String] identifiedBy Symbol("welcome") to None) :: DynamicModule({ m =>
+        m.binding identifiedBy Symbol("tcpHost") to "test"
+        m.binding identifiedBy Symbol("welcome") to "Hello user!"
       })
 
-      val binding = module.getBinding(List('tcpServer))
-      binding should be ('defined)
+      val binding = module.getBinding(List(Symbol("tcpServer")))
+      binding should be (Symbol("defined"))
 
       val server = binding.get.get.get.asInstanceOf[TcpServer]
       server.getConnection.welcomeMessage should equal ("Hi")
@@ -45,11 +45,11 @@ class InjectableSpec extends WordSpec with Matchers {
 
     "inject using identifiers" in {
       val results = List (
-        inject [Database] ('database and 'local),
-        inject [Database] (identified by 'local and 'database),
-        inject [Database] (by default defaultDb and identified by 'database and 'local),
-        inject [Database] (by default new MysqlDatabase("my_app") and 'database and 'local),
-        inject [Database] ('database and "local" and by default defaultDb)
+        inject [Database] (Symbol("database") and Symbol("local")),
+        inject [Database] (identified by Symbol("local") and Symbol("database")),
+        inject [Database] (by default defaultDb and identified by Symbol("database") and Symbol("local")),
+        inject [Database] (by default new MysqlDatabase("my_app") and Symbol("database") and Symbol("local")),
+        inject [Database] (Symbol("database") and "local" and by default defaultDb)
       )
 
       results should have size 5
@@ -58,14 +58,14 @@ class InjectableSpec extends WordSpec with Matchers {
 
     "inject default if binding not found" in {
       val results = List [Database] (
-        inject [Database] (identified by 'remote and by default new PostgresqlDatabase("default_db")),
-        inject [Database] (identified by 'remote is by default defaultDb),
-        inject [Database] ('remote is by default defaultDb),
-        inject [Database] ('remote which by default defaultDb),
-        inject [Database] ('remote that by default defaultDb),
-        inject [Database] (by default defaultDb and identified by 'remote),
+        inject [Database] (identified by Symbol("remote") and by default new PostgresqlDatabase("default_db")),
+        inject [Database] (identified by Symbol("remote") is by default defaultDb),
+        inject [Database] (Symbol("remote") is by default defaultDb),
+        inject [Database] (Symbol("remote") which by default defaultDb),
+        inject [Database] (Symbol("remote") that by default defaultDb),
+        inject [Database] (by default defaultDb and identified by Symbol("remote")),
         inject (by default defaultDb),
-        inject (by default defaultDb and 'local),
+        inject (by default defaultDb and Symbol("local")),
         inject (by default new PostgresqlDatabase("default_db"))
       )
 
@@ -78,19 +78,19 @@ class InjectableSpec extends WordSpec with Matchers {
       var str2Counter = 0
 
       implicit val injector = DynamicModule({ m =>
-        m.binding identifiedBy 'str1 to {
+        m.binding identifiedBy Symbol("str1") to {
           str1Counter = str1Counter + 1
           s"str1 $str1Counter"
         }
 
-        m.binding identifiedBy 'str2 toProvider {
+        m.binding identifiedBy Symbol("str2") toProvider {
           str2Counter = str2Counter + 1
           s"str2 $str2Counter"
         }
       })
 
-      val str1 = injectProvider[String]('str1)
-      val str2 = injectProvider[String]('str2)
+      val str1 = injectProvider[String](Symbol("str1"))
+      val str2 = injectProvider[String](Symbol("str2"))
 
       str1() should equal ("str1 1")
       str1() should equal ("str1 1")
@@ -107,7 +107,7 @@ class InjectableSpec extends WordSpec with Matchers {
     }
 
     "also be available in module, but use resulting (compised) injector" in {
-      val server = inject [Server] ('real and 'http)
+      val server = inject [Server] (Symbol("real") and Symbol("http"))
       server should equal (HttpServer("marketing.org", 8081))
     }
 
@@ -120,7 +120,7 @@ class InjectableSpec extends WordSpec with Matchers {
     }
 
     "inject all using type parameter" in {
-      injectAllOfType [String] ('host) should
+      injectAllOfType [String] (Symbol("host")) should
           (contain("www.google.com") and contain("www.yahoo.com") and contain("www.github.com") and have size 3)
 
       injectAllOfType [HttpServer] should
@@ -128,10 +128,10 @@ class InjectableSpec extends WordSpec with Matchers {
     }
 
     "inject all without type parameter" in {
-      injectAll('host).asInstanceOf[List[String]] should
+      injectAll(Symbol("host")).asInstanceOf[List[String]] should
           (contain("www.google.com") and contain("www.yahoo.com") and contain("www.github.com") and have size 3)
 
-      injectAll('server).asInstanceOf[List[HttpServer]] should
+      injectAll(Symbol("server")).asInstanceOf[List[HttpServer]] should
           (contain(HttpServer("localhost", 80)) and contain(HttpServer("test", 8080)) and have size 2)
     }
 
@@ -141,38 +141,38 @@ class InjectableSpec extends WordSpec with Matchers {
     }
 
     "inject some values identified by names" in {
-      injectOpt[String]('httpHost) should equal(Some("marketing.org"))
-      injectOpt[String]('host and 'github) should equal(Some("www.github.com"))
-      injectOpt[Database] should be ('defined)
+      injectOpt[String](Symbol("httpHost")) should equal(Some("marketing.org"))
+      injectOpt[String](Symbol("host") and Symbol("github")) should equal(Some("www.github.com"))
+      injectOpt[Database] should be (Symbol("defined"))
     }
 
     "inject optional default values" in {
-      injectOpt[String]('nonSpecified is by default "default value") should equal(Some("default value"))
+      injectOpt[String](Symbol("nonSpecified") is by default "default value") should equal(Some("default value"))
     }
   }
 
   implicit lazy val injector: Injector = mainModule :: marketingModule
 
   val marketingModule = new Module {
-    bind [String] identifiedBy 'httpHost to "marketing.org"
+    bind [String] identifiedBy Symbol("httpHost") to "marketing.org"
   }
 
   val mainModule = new Module {
-    binding identifiedBy 'host and 'google to "www.google.com"
-    binding identifiedBy 'host and 'yahoo to "www.yahoo.com"
-    binding identifiedBy 'host and 'github to "www.github.com"
+    binding identifiedBy Symbol("host") and Symbol("google") to "www.google.com"
+    binding identifiedBy Symbol("host") and Symbol("yahoo") to "www.yahoo.com"
+    binding identifiedBy Symbol("host") and Symbol("github") to "www.github.com"
 
-    binding identifiedBy 'server to HttpServer("localhost", 80)
-    binding identifiedBy 'server to None
-    binding identifiedBy 'server to HttpServer("test", 8080)
+    binding identifiedBy Symbol("server") to HttpServer("localhost", 80)
+    binding identifiedBy Symbol("server") to None
+    binding identifiedBy Symbol("server") to HttpServer("test", 8080)
 
-    binding identifiedBy 'intAdder to ((a: Int, b: Int) => a + b)
-    binding identifiedBy 'stringAdder to ((s1: String, s2: String) => s1 + ", " + s2)
+    binding identifiedBy Symbol("intAdder") to ((a: Int, b: Int) => a + b)
+    binding identifiedBy Symbol("stringAdder") to ((s1: String, s2: String) => s1 + ", " + s2)
 
-    bind [Int] identifiedBy 'httpPort to 8081
+    bind [Int] identifiedBy Symbol("httpPort") to 8081
 
-    bind [Server] identifiedBy 'real and 'http to HttpServer(inject [String] ('httpHost), inject [Int] ('httpPort))
+    bind [Server] identifiedBy Symbol("real") and Symbol("http") to HttpServer(inject [String] (Symbol("httpHost")), inject [Int] (Symbol("httpPort")))
 
-    binding identifiedBy 'database and "local" to MysqlDatabase("my_app")
+    binding identifiedBy Symbol("database") and "local" to MysqlDatabase("my_app")
   }
 }

--- a/src/test/scala/scaldi/InjectedMacroSpec.scala
+++ b/src/test/scala/scaldi/InjectedMacroSpec.scala
@@ -42,7 +42,7 @@ class InjectedMacroSpec extends WordSpec with Matchers {
 
     "support overrides" in {
       implicit val inj = new Module {
-        bind [DepWithDefaults] to injected [DepWithDefaults] ('d1 -> Dep1("Override"), 'd3 -> Dep2("Another override"))
+        bind [DepWithDefaults] to injected [DepWithDefaults] (Symbol("d1") -> Dep1("Override"), Symbol("d3") -> Dep2("Another override"))
 
         bind [Server] to new HttpServer("localhost", 80)
         binding to Dep1("Defined in module")
@@ -60,10 +60,10 @@ class InjectedMacroSpec extends WordSpec with Matchers {
 }
 
 class ImplicitArgumentsModule extends Module {
-  bind to injected [ImplicitArguments] ('dep1 -> inject [Dep1] (identified by 'foo))
+  bind to injected [ImplicitArguments] (Symbol("dep1") -> inject [Dep1] (identified by Symbol("foo")))
 
-  bind [Dep1] identifiedBy 'foo to Dep1("foo")
-  bind [Dep1] identifiedBy 'bar to Dep1("bar")
+  bind [Dep1] identifiedBy Symbol("foo") to Dep1("foo")
+  bind [Dep1] identifiedBy Symbol("bar") to Dep1("bar")
 
   binding to Dep2("foo")
   binding to Dep3("foo")
@@ -71,9 +71,9 @@ class ImplicitArgumentsModule extends Module {
 
 case class ImplicitArguments(dep1: Dep1, dep2: Dep2, dep3: Dep3)(implicit inj: Injector)
 
-class DepSimple(a: String, s: Server) extends Debug('a -> a, 's -> s)
-class DepWithDefaults(d1: Dep1 = Dep1("Default Value"), d2: Server, d3: Dep2 = Dep2("123")) extends Debug('d1 -> d1, 'd2 -> d2, 'd3 -> d3)
-class DepMultiArgList(a: String, s: Server)(l: Long)(l1: Long, c: List[Int]) extends Debug('a -> a, 's -> s, 'l -> l, 'l1 -> l1, 'c -> c)
+class DepSimple(a: String, s: Server) extends Debug(Symbol("a") -> a, Symbol("s") -> s)
+class DepWithDefaults(d1: Dep1 = Dep1("Default Value"), d2: Server, d3: Dep2 = Dep2("123")) extends Debug(Symbol("d1") -> d1, Symbol("d2") -> d2, Symbol("d3") -> d3)
+class DepMultiArgList(a: String, s: Server)(l: Long)(l1: Long, c: List[Int]) extends Debug(Symbol("a") -> a, Symbol("s") -> s, Symbol("l") -> l, Symbol("l1") -> l1, Symbol("c") -> c)
 
 class Debug(val props: (Symbol, Any)*) {
   // hashCode is not overridden because I will use only equals in the test

--- a/src/test/scala/scaldi/InjectorSpec.scala
+++ b/src/test/scala/scaldi/InjectorSpec.scala
@@ -53,7 +53,7 @@ class InjectorSpec extends WordSpec with Matchers {
     "provide implicit injector and be Injectable" in {
       implicit val module = new StaticModule {
         lazy val server = new TcpServer
-        lazy val otherServer = HttpServer(inject [String] ("httpHost"), inject [Int] ('httpPort))
+        lazy val otherServer = HttpServer(inject [String] ("httpHost"), inject [Int] (Symbol("httpPort")))
 
         val tcpHost = "tcp-test"
         val tcpPort = 1234
@@ -76,13 +76,13 @@ class InjectorSpec extends WordSpec with Matchers {
     "provide implicit injector and be Injectable" in {
       implicit val module = new DynamicModule {
         binding to new TcpServer
-        binding to HttpServer(inject [String] ("httpHost"), inject [Int] ('httpPort))
+        binding to HttpServer(inject [String] ("httpHost"), inject [Int] (Symbol("httpPort")))
 
-        bind [String] as 'tcpHost to "tcp-test"
-        bind [Int] as 'tcpPort to 1234
+        bind [String] as Symbol("tcpHost") to "tcp-test"
+        bind [Int] as Symbol("tcpPort") to 1234
 
-        binding identifiedBy 'httpHost to "localhost"
-        binding identifiedBy 'httpPort to 4321
+        binding identifiedBy Symbol("httpHost") to "localhost"
+        binding identifiedBy Symbol("httpPort") to 4321
       }
 
       val server = Injectable.inject [TcpServer]
@@ -145,23 +145,23 @@ class InjectorSpec extends WordSpec with Matchers {
 
       inject[Server] should equal (HttpServer("test-prop", 54321))
 
-      inject[Integer]('port) should equal (Integer.valueOf(54321))
+      inject[Integer](Symbol("port")) should equal (Integer.valueOf(54321))
     }
   }
 
   class AppModule extends Module {
-    bind [Server] to HttpServer(inject [String] ('host), inject [Int] ('port))
+    bind [Server] to HttpServer(inject [String] (Symbol("host")), inject [Int] (Symbol("port")))
 
-    binding identifiedBy 'host to "localhost"
-    binding identifiedBy 'port to 80
+    binding identifiedBy Symbol("host") to "localhost"
+    binding identifiedBy Symbol("port") to 80
   }
 
   class Test1Module extends Module {
-    binding identifiedBy 'host to "test"
+    binding identifiedBy Symbol("host") to "test"
   }
 
   class Test2Module extends Module {
-    binding identifiedBy 'host to "test2"
-    binding identifiedBy 'port to 8080
+    binding identifiedBy Symbol("host") to "test2"
+    binding identifiedBy Symbol("port") to 8080
   }
 }

--- a/src/test/scala/scaldi/LifecycleSpec.scala
+++ b/src/test/scala/scaldi/LifecycleSpec.scala
@@ -10,11 +10,11 @@ class LifecycleSpec extends WordSpec with Matchers {
   "BindingLifecycle" should {
     "allow to define init function which should be called one time for lazy and non-lazy bindings" in {
       val module1 = new Module {
-        bind [Server] as 'serverLazy to new LifecycleServer initWith (_.init())
+        bind [Server] as Symbol("serverLazy") to new LifecycleServer initWith (_.init())
       }
 
       val module2 = new Module {
-        bind [Server] as 'serverNonLazy toNonLazy new LifecycleServer initWith (_.init())
+        bind [Server] as Symbol("serverNonLazy") toNonLazy new LifecycleServer initWith (_.init())
       }
 
       implicit val moduleAggregation = module1 :: module2
@@ -22,24 +22,24 @@ class LifecycleSpec extends WordSpec with Matchers {
       import Injectable._
 
       (1 to 20) foreach { _ =>
-        inject[Server]('serverLazy)
-        inject[Server]('serverNonLazy)
+        inject[Server](Symbol("serverLazy"))
+        inject[Server](Symbol("serverNonLazy"))
       }
 
-      inject[Server]('serverLazy).asInstanceOf[LifecycleServer].initializedCount should equal (1)
-      inject[Server]('serverNonLazy).asInstanceOf[LifecycleServer].initializedCount should equal (1)
+      inject[Server](Symbol("serverLazy")).asInstanceOf[LifecycleServer].initializedCount should equal (1)
+      inject[Server](Symbol("serverNonLazy")).asInstanceOf[LifecycleServer].initializedCount should equal (1)
     }
 
     "allow to define init function for provider bindings which should be called one time for each created object" in {
       var instanceCount = 0
 
       implicit val module = new Module {
-        bind [Server] as 'server toProvider {instanceCount = instanceCount + 1; new LifecycleServer} initWith (_.init())
+        bind [Server] as Symbol("server") toProvider {instanceCount = instanceCount + 1; new LifecycleServer} initWith (_.init())
       }
 
       import Injectable._
 
-      val instances = (1 to 20).toList map (_ => inject[Server]('server))
+      val instances = (1 to 20).toList map (_ => inject[Server](Symbol("server")))
 
       instanceCount should be (20)
       instances foreach (_.asInstanceOf[LifecycleServer].initializedCount should equal (1))
@@ -47,21 +47,21 @@ class LifecycleSpec extends WordSpec with Matchers {
 
     "allow to define destroy function which should be called one time for every created instance" in {
       val module1 = new Module {
-        bind [Server] as 'serverLazy to new LifecycleServer destroyWith (_.terminate())
+        bind [Server] as Symbol("serverLazy") to new LifecycleServer destroyWith (_.terminate())
       }
 
       val module2 = new Module {
-        bind [Server] as 'serverNonLazy toNonLazy  new LifecycleServer destroyWith (_.terminate())
-        bind [Server] as 'serverProvider toProvider new LifecycleServer destroyWith (_.terminate())
+        bind [Server] as Symbol("serverNonLazy") toNonLazy  new LifecycleServer destroyWith (_.terminate())
+        bind [Server] as Symbol("serverProvider") toProvider new LifecycleServer destroyWith (_.terminate())
       }
 
       implicit val moduleAggregation = module1 :: module2
 
       import Injectable._
 
-      val serverLazy = inject[Server] ('serverLazy)
-      val serverNonLazy = inject[Server] ('serverNonLazy)
-      val serverProvider = inject[Server] ('serverProvider)
+      val serverLazy = inject[Server] (Symbol("serverLazy"))
+      val serverNonLazy = inject[Server] (Symbol("serverNonLazy"))
+      val serverProvider = inject[Server] (Symbol("serverProvider"))
 
       1 to 20 foreach (_ => moduleAggregation.destroy())
       
@@ -73,26 +73,26 @@ class LifecycleSpec extends WordSpec with Matchers {
 
   "ShutdownHookLifecycleManager" should {
     "not allow to add destroyable after it was already destroyed" in {
-      JvmTestUtil.shutdownHookCount should be (0)
+      val initialShutdownHookCount = JvmTestUtil.shutdownHookCount
 
       implicit val module = new Module {
-        bind [Server] as 'server to new LifecycleServer initWith (_.init()) destroyWith (_.terminate())
+        bind [Server] as Symbol("server") to new LifecycleServer initWith (_.init()) destroyWith (_.terminate())
       }
 
       import Injectable._
 
-      inject[Server]('server).asInstanceOf[LifecycleServer].initializedCount should be (1)
+      inject[Server](Symbol("server")).asInstanceOf[LifecycleServer].initializedCount should be (1)
 
       val destroyedCount = new AtomicInteger(0)
 
       module.addDestroyable(() => destroyedCount.incrementAndGet())
 
-      JvmTestUtil.shutdownHookCount should be (1)
+      JvmTestUtil.shutdownHookCount should be (initialShutdownHookCount + 1)
 
       module.destroy()
 
       destroyedCount.get should be (1)
-      JvmTestUtil.shutdownHookCount should be (0)
+      JvmTestUtil.shutdownHookCount should be (initialShutdownHookCount)
 
       an [IllegalStateException] should be thrownBy
           module.addDestroyable(() => destroyedCount.incrementAndGet())

--- a/src/test/scala/scaldi/ReflectionBinderSpec.scala
+++ b/src/test/scala/scaldi/ReflectionBinderSpec.scala
@@ -12,7 +12,7 @@ class ReflectionBinderSpec extends WordSpec with Matchers {
         lazy val server = new HttpServer("localhost", 80)
       }
 
-      binder.getBinding(List("server", classOf[HttpServer])) should be('defined)
+      binder.getBinding(List("server", classOf[HttpServer])) should be(Symbol("defined"))
     }
 
     "infer correct type and string identifier taken from member name" in {
@@ -22,7 +22,7 @@ class ReflectionBinderSpec extends WordSpec with Matchers {
       }
 
       binder.getBinding(List("myHttpServer", classOf[Server])).get.get should equal (Some(HttpServer("localhost", 80)))
-      binder.getBinding(List("myHttpServer", classOf[HttpServer])) should be ('empty)
+      binder.getBinding(List("myHttpServer", classOf[HttpServer])) should be (Symbol("empty"))
 
       binder.getBinding(List("otherServer", classOf[Server])).get.get should equal (Some(HttpServer("test", 8080)))
       binder.getBinding(List("otherServer", classOf[HttpServer])).get.get should equal (Some(HttpServer("test", 8080)))
@@ -33,8 +33,8 @@ class ReflectionBinderSpec extends WordSpec with Matchers {
         lazy val someBinding = SpecialBindingProvider(() => HttpServer("test", 8080))
       }
 
-      binder.getBinding(List("someBinding")) should be ('empty)
-      binder.getBinding(List(classOf[BindingProvider])) should be ('empty)
+      binder.getBinding(List("someBinding")) should be (Symbol("empty"))
+      binder.getBinding(List(classOf[BindingProvider])) should be (Symbol("empty"))
       binder.getBinding(List(classOf[Server])).get.get should equal (Some(HttpServer("test", 8080)))
       binder.getBinding(List("special")).get.get should equal (Some(HttpServer("test", 8080)))
     }

--- a/src/test/scala/scaldi/WordBinderSpec.scala
+++ b/src/test/scala/scaldi/WordBinderSpec.scala
@@ -8,7 +8,7 @@ class WordBinderSpec extends WordSpec with Matchers {
     "require to bind something" in {
       val binder = new WordBinder {
 
-        bind [String] identifiedBy 'host
+        bind [String] identifiedBy Symbol("host")
 
         override def injector = ???
       }
@@ -18,12 +18,12 @@ class WordBinderSpec extends WordSpec with Matchers {
 
     "collect all identifiers for bindings" in {
       val binder = new WordBinder {
-        bind [String] identifiedBy 'host and "httpServer" to "localhost"
-        bind [String] as 'host and "httpServer" to "localhost"
-        binding identifiedBy classOf[String] and 'host and "httpServer" to "localhost"
-        bind [String] to "localhost" identifiedBy 'host and "httpServer"
-        bind [String] to "localhost" as 'host and "httpServer"
-        binding to "localhost" identifiedBy classOf[String] and 'host and "httpServer"
+        bind [String] identifiedBy Symbol("host") and "httpServer" to "localhost"
+        bind [String] as Symbol("host") and "httpServer" to "localhost"
+        binding identifiedBy classOf[String] and Symbol("host") and "httpServer" to "localhost"
+        bind [String] to "localhost" identifiedBy Symbol("host") and "httpServer"
+        bind [String] to "localhost" as Symbol("host") and "httpServer"
+        binding to "localhost" identifiedBy classOf[String] and Symbol("host") and "httpServer"
 
         override def injector = ???
       }
@@ -74,12 +74,12 @@ class WordBinderSpec extends WordSpec with Matchers {
     "allow to define normal lazy bindings that would be instantiated only one time" in {
       var instanceCount = 0
       val binder = new DynamicModule {
-        bind [Server] identifiedBy 'server and "httpServer" to {
+        bind [Server] identifiedBy Symbol("server") and "httpServer" to {
           instanceCount  += 1
           new HttpServer("localhost", Random.nextInt())
         }
 
-        bind [Server] identifiedBy 'otherServer to HttpServer("test", 8080)
+        bind [Server] identifiedBy Symbol("otherServer") to HttpServer("test", 8080)
       }.initNonLazy()
 
       instanceCount should be (0)
@@ -91,12 +91,12 @@ class WordBinderSpec extends WordSpec with Matchers {
     "allow to define normal non-lazy bindings that would be instantiated only one time" in {
       var instanceCount = 0
       val binder = new DynamicModule {
-        bind [Server] identifiedBy 'server and "httpServer" toNonLazy {
+        bind [Server] identifiedBy Symbol("server") and "httpServer" toNonLazy {
           instanceCount  += 1
           new HttpServer("localhost", Random.nextInt())
         }
 
-        bind [Server] identifiedBy 'otherServer toNonLazy HttpServer("test", 8080)
+        bind [Server] identifiedBy Symbol("otherServer") toNonLazy HttpServer("test", 8080)
       }.initNonLazy()
 
       instanceCount should be (1)
@@ -108,12 +108,12 @@ class WordBinderSpec extends WordSpec with Matchers {
     "allow to define provider bindings that would be instantiated each time" in {
       var instanceCount = 0
       val binder = new DynamicModule {
-        bind [Server] identifiedBy 'server and "httpServer" toProvider {
+        bind [Server] identifiedBy Symbol("server") and "httpServer" toProvider {
           instanceCount  += 1
           new HttpServer("localhost", Random.nextInt())
         }
 
-        bind [Server] identifiedBy 'otherServer toProvider HttpServer("test", 8080)
+        bind [Server] identifiedBy Symbol("otherServer") toProvider HttpServer("test", 8080)
       }.initNonLazy()
 
       instanceCount should be (0)
@@ -131,67 +131,67 @@ class WordBinderSpec extends WordSpec with Matchers {
         val SpecialMode = Condition(specialMode)
         val DevMode = !ProdMode
 
-        bind [String] as 'host when ProdMode to "www.prod-server.com"
-        bind [String] as 'host when DevMode to "localhost"
+        bind [String] as Symbol("host") when ProdMode to "www.prod-server.com"
+        bind [String] as Symbol("host") when DevMode to "localhost"
 
-        bind [Int] as 'id when ProdMode when SpecialMode to 123
+        bind [Int] as Symbol("id") when ProdMode when SpecialMode to 123
 
-        bind [Int] when ProdMode as 'port to 1234
+        bind [Int] when ProdMode as Symbol("port") to 1234
 
         when (DevMode) {
-          bind [String] as 'userName to "testUser"
-          bind [Long] as 'timeout to 1000L
+          bind [String] as Symbol("userName") to "testUser"
+          bind [Long] as Symbol("timeout") to 1000L
 
-          bind [String] when SpecialMode as 'path to "/index.html"
+          bind [String] when SpecialMode as Symbol("path") to "/index.html"
 
           when (SpecialMode) {
-            bind [String] as 'password to "secret"
+            bind [String] as Symbol("password") to "secret"
           }
         }
       }
 
       binder.wordBindings should have size 9
 
-      binder.getBinding(List('host)).get.get.get should equal ("www.prod-server.com")
-      binder.getBinding(List('port)).get.get.get should equal (1234)
-      binder.getBinding(List('userName)) should be ('empty)
-      binder.getBinding(List('timeout)) should be ('empty)
-      binder.getBinding(List('path)) should be ('empty)
-      binder.getBinding(List('password)) should be ('empty)
-      binder.getBinding(List('id)).get.get.get should equal (123)
+      binder.getBinding(List(Symbol("host"))).get.get.get should equal ("www.prod-server.com")
+      binder.getBinding(List(Symbol("port"))).get.get.get should equal (1234)
+      binder.getBinding(List(Symbol("userName"))) should be (Symbol("empty"))
+      binder.getBinding(List(Symbol("timeout"))) should be (Symbol("empty"))
+      binder.getBinding(List(Symbol("path"))) should be (Symbol("empty"))
+      binder.getBinding(List(Symbol("password"))) should be (Symbol("empty"))
+      binder.getBinding(List(Symbol("id"))).get.get.get should equal (123)
 
       specialMode = false
       prodMode = false
 
-      binder.getBinding(List('host)).get.get.get should equal ("localhost")
-      binder.getBinding(List('port)) should be ('empty)
-      binder.getBinding(List('userName)).get.get.get should equal ("testUser")
-      binder.getBinding(List('timeout)).get.get.get should be (1000L)
-      binder.getBinding(List('path)) should be ('empty)
-      binder.getBinding(List('password)) should be ('empty)
-      binder.getBinding(List('id)) should be ('empty)
+      binder.getBinding(List(Symbol("host"))).get.get.get should equal ("localhost")
+      binder.getBinding(List(Symbol("port"))) should be (Symbol("empty"))
+      binder.getBinding(List(Symbol("userName"))).get.get.get should equal ("testUser")
+      binder.getBinding(List(Symbol("timeout"))).get.get.get should be (1000L)
+      binder.getBinding(List(Symbol("path"))) should be (Symbol("empty"))
+      binder.getBinding(List(Symbol("password"))) should be (Symbol("empty"))
+      binder.getBinding(List(Symbol("id"))) should be (Symbol("empty"))
 
       specialMode = true
 
-      binder.getBinding(List('path)).get.get.get should equal ("/index.html")
-      binder.getBinding(List('password)).get.get.get should be ("secret")
-      binder.getBinding(List('id)) should be ('empty)
+      binder.getBinding(List(Symbol("path"))).get.get.get should equal ("/index.html")
+      binder.getBinding(List(Symbol("password"))).get.get.get should be ("secret")
+      binder.getBinding(List(Symbol("id"))) should be (Symbol("empty"))
     }
 
     "allow to define init and destroy functions" in {
       implicit val module = new DynamicModule {
-        bind [Server] as 'server1 to new LifecycleServer initWith (_.init()) destroyWith (_.terminate())
-        bind [Server] as 'server2 to new LifecycleServer initWith (_.init())
-        bind [Server] as 'server3 to new LifecycleServer destroyWith (_.terminate())
+        bind [Server] as Symbol("server1") to new LifecycleServer initWith (_.init()) destroyWith (_.terminate())
+        bind [Server] as Symbol("server2") to new LifecycleServer initWith (_.init())
+        bind [Server] as Symbol("server3") to new LifecycleServer destroyWith (_.terminate())
       }
 
       import Injectable._
 
       (1 to 3) foreach (i => inject[Server](s"server$i"))
 
-      val server1 = inject[Server]('server1).asInstanceOf[LifecycleServer]
-      val server2 = inject[Server]('server2).asInstanceOf[LifecycleServer]
-      val server3 = inject[Server]('server3).asInstanceOf[LifecycleServer]
+      val server1 = inject[Server](Symbol("server1")).asInstanceOf[LifecycleServer]
+      val server2 = inject[Server](Symbol("server2")).asInstanceOf[LifecycleServer]
+      val server3 = inject[Server](Symbol("server3")).asInstanceOf[LifecycleServer]
 
       server1.initializedCount should equal (1)
       server1.destroyedCount should equal (0)

--- a/src/test/scala/scaldi/testData.scala
+++ b/src/test/scala/scaldi/testData.scala
@@ -19,12 +19,12 @@ case class MysqlDatabase(name: String) extends Database with ConnectionProvider
 case class PostgresqlDatabase(name: String) extends Database with ConnectionProvider
 
 class TcpModule extends Module {
-  binding identifiedBy 'tcpServer to new TcpServer
+  binding identifiedBy Symbol("tcpServer") to new TcpServer
 }
 
 class TcpServer(implicit inj: Injector) extends Server with Injectable  {
-  val port = inject [Int] ('tcpPort is by default 1234)
-  val host = inject [String] ('tcpHost)
+  val port = inject [Int] (Symbol("tcpPort") is by default 1234)
+  val host = inject [String] (Symbol("tcpHost"))
 
   def getConnection = new TcpConnection
 }
@@ -32,7 +32,7 @@ class TcpServer(implicit inj: Injector) extends Server with Injectable  {
 import scaldi.Injectable._
 
 class TcpConnection(implicit inj: Injector) {
-  val welcomeMessage = inject [String] ('welcome is by default "Hi")
+  val welcomeMessage = inject [String] (Symbol("welcome") is by default "Hi")
 }
 
 case class Dep1(name: String)

--- a/src/test/scala/scaldi/util/JvmTestUtil.scala
+++ b/src/test/scala/scaldi/util/JvmTestUtil.scala
@@ -3,7 +3,7 @@ package scaldi.util
 object JvmTestUtil {
 
   // It is not pretty at all, but if you know better way to get JVM shutdown hook count, I would be happy to use it :)
-  def shutdownHookCount = {
+  def shutdownHookCount: Int = {
     val hooksField = Class.forName("java.lang.ApplicationShutdownHooks").getDeclaredField("hooks")
 
     if (!hooksField.isAccessible) hooksField.setAccessible(true)


### PR DESCRIPTION
Update code to support 2.11 through 2.13.

Fix deprecation warnings from 2.13.

Update scala, sbt, plugin and dependency versions.

Update travis build matrix to build against Java 8 and 11.