### PR TITLE
De-alias types in TypeTagIdentifier

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "dipendi"
 organization := "com.protenus"
-version := "0.5.9-SNAPSHOT"
+version := "0.6.0-SNAPSHOT"
 
 description := "Dipendi - Scala Dependency Injection Library"
 homepage := Some(url("https://github.com/protenus/dipendi"))

--- a/src/main/scala/scaldi/Identifier.scala
+++ b/src/main/scala/scaldi/Identifier.scala
@@ -116,7 +116,7 @@ object CanBeIdentifier {
   * Identifier created from any Scala type
   * @param tpe instance that will be defined as in `Identifier`
   */
-case class TypeTagIdentifier(tpe: Type) extends Identifier {
+final class TypeTagIdentifier private(val tpe: Type) extends Identifier {
   /**
     * @inheritdoc
     */
@@ -125,6 +125,13 @@ case class TypeTagIdentifier(tpe: Type) extends Identifier {
       case TypeTagIdentifier(otherTpe) if ReflectionHelper.isAssignableFrom(otherTpe, tpe) => true
       case _ => false
     }
+
+  override def equals(obj: Any): Boolean = obj match {
+    case that: TypeTagIdentifier => this.tpe == that.tpe
+    case _ => false
+  }
+  override def hashCode(): Int = tpe.hashCode()
+  override def toString: String = s"TypeTagIdentifier($tpe)"
 }
 
 object TypeTagIdentifier {
@@ -133,7 +140,12 @@ object TypeTagIdentifier {
     * @tparam T `TypeTag` containing type parameter
     * @return Generated `Identifier`
     */
-  def typeId[T: TypeTag] = TypeTagIdentifier(implicitly[TypeTag[T]].tpe)
+  def typeId[T: TypeTag]: TypeTagIdentifier = apply(implicitly[TypeTag[T]].tpe)
+
+  def apply(tpe: Type): TypeTagIdentifier =
+    new TypeTagIdentifier(tpe.dealias)
+
+  def unapply(that: TypeTagIdentifier): Some[Type] = Some(that.tpe)
 }
 
 /**

--- a/src/test/scala/scaldi/IdentifierSpec.scala
+++ b/src/test/scala/scaldi/IdentifierSpec.scala
@@ -5,6 +5,8 @@ import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class IdentifierSpec extends AnyWordSpec with Matchers {
+  private type Bar = List[Int]
+
   "Identifier" when {
     "defaults are used" should {
       "be converted from string" in {
@@ -21,21 +23,29 @@ class IdentifierSpec extends AnyWordSpec with Matchers {
     }
 
     "compared" should {
-      "should not match for different identifier types" in {
+      "not match for different identifier types" in {
         getId(classOf[DateFormat]) sameAs getId("java.text.DateFormat") should be (false)
       }
 
-      "should match for the same identifier types" in {
-        getId(Symbol("publisher")) sameAs getId("publisher") should be (true)
+      "not match for different identifier values" in {
         getId(Symbol("user")) sameAs getId("publisher") should be (false)
-
-        getId(classOf[String]) sameAs getId(classOf[String]) should be (true)
         getId(classOf[DateFormat]) sameAs getId(classOf[String]) should be (false)
       }
 
-      "use polymothism to compare classes" in {
+      "match for the same identifier types and values" in {
+        getId(Symbol("publisher")) sameAs getId("publisher") should be (true)
+        getId(classOf[String]) sameAs getId(classOf[String]) should be (true)
+      }
+
+      "use polymorphism to compare classes" in {
         getId(classOf[SimpleDateFormat]) sameAs getId(classOf[DateFormat]) should be (true)
         getId(classOf[DateFormat]) sameAs getId(classOf[SimpleDateFormat]) should be (false)
+      }
+
+      "treat type-aliases as their values" in {
+        getId(classOf[List[Int]]) should equal (getId(classOf[Bar]))
+        getId(classOf[Bar]) should equal (getId(classOf[List[Int]]))
+        getId(classOf[Bar]) should equal (getId(classOf[Bar]))
       }
     }
   }


### PR DESCRIPTION
De-alias types in `TypeTagIdentifier` so that a binding
for a type alias can be found by an identifier for that
alias's value.

Due to restrictions in 2.11, the `TypeTagIdentifier.apply` cannot
be overridden; as a result, this changes the class to not to be a
case class. As part of this change which may not be binary
compatible, the version is bumped to 0.6.0-SNAPSHOT.